### PR TITLE
feat: set default dpi values for linux and macos

### DIFF
--- a/main.odin
+++ b/main.odin
@@ -37,8 +37,10 @@ get_exe_filename :: proc() -> cstring {
 get_scale :: proc() -> f64 {
 	dpi: f32
 	_ = sdl.GetDisplayDPI(0, nil, &dpi, nil)
-	when ODIN_OS == .Windows {
+	when ODIN_OS == .Windows || ODIN_OS == .Linux{
 		return f64(dpi) / 96.0
+	} else when ODIN_OS == .Darwin {
+		return f64(dpi) / 72.0
 	}
 	return 1.0
 }


### PR DESCRIPTION
Was not able to yet test on a mac(will try to do it and post the results) but 72 seems to be the default for MacOS as referred across the web. In linux the value is referred to be the same as Windows and it's working fine after some quick testing.